### PR TITLE
Upgrade to bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ bevy_ggrs = ["dep:bevy_ggrs"]
 math_determinism = ["bevy_math/libm"]
 
 [dependencies]
-bevy = { version = "0.13", default-features = false }
-bevy_math = "0.13"
-bevy_ggrs = { version = "0.15", optional = true, default-features = false }
+bevy = { version = "0.14", default-features = false, features = ["bevy_state"] }
+bevy_math = "0.14"
+bevy_ggrs = { version = "0.16", optional = true, default-features = false }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Some of Bevy's features can't be used in a rollback context (with crates such as
 ## Roadmap
 
 - [x] States
+  - [x] Basic freely mutable states
+  - [x] `OnEnter`/`OnLeave`/`OnTransition`
+  - [ ] Sub-States
+  - [ ] Computed states
+  - [ ] Roll-safe events
 - [x] FrameCount
 - [ ] Events
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ See the [`states`](https://github.com/johanhelsing/bevy_roll_safe/blob/main/exam
 
 |bevy|bevy_roll_safe|
 |----|--------------|
-|0.13|0.2, main     |
+|0.14|0.3, main     |
+|0.13|0.2           |
 |0.12|0.1           |
 
 ## License

--- a/examples/states.rs
+++ b/examples/states.rs
@@ -6,7 +6,7 @@ use bevy_ggrs::{
     prelude::*,
     LocalInputs, LocalPlayers,
 };
-use bevy_roll_safe::{prelude::*, run_state_transitions};
+use bevy_roll_safe::prelude::*;
 
 type GgrsConfig = bevy_ggrs::GgrsConfig<u8, String>;
 
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .add_systems(
             GgrsSchedule,
             decrease_health
-                .after(run_state_transitions)
+                .after(bevy_roll_safe::apply_state_transition::<GameplayState>)
                 .run_if(in_state(GameplayState::InRound)),
         )
         .insert_resource(Session::SyncTest(session))

--- a/examples/states.rs
+++ b/examples/states.rs
@@ -6,7 +6,7 @@ use bevy_ggrs::{
     prelude::*,
     LocalInputs, LocalPlayers,
 };
-use bevy_roll_safe::prelude::*;
+use bevy_roll_safe::{prelude::*, run_state_transitions};
 
 type GgrsConfig = bevy_ggrs::GgrsConfig<u8, String>;
 
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .add_systems(
             GgrsSchedule,
             decrease_health
-                .after(apply_state_transition::<GameplayState>)
+                .after(run_state_transitions)
                 .run_if(in_state(GameplayState::InRound)),
         )
         .insert_resource(Session::SyncTest(session))


### PR DESCRIPTION
- [x] Figure out of initial state entering hacks are still needed
- [x] Fix bug and panic in states example

Bevy states implementation and API changed quite a lot. So this requires some rewriting to work properly. Perhaps even copying the old implementation of bevy states?